### PR TITLE
T004 on off effort

### DIFF
--- a/sammo.py
+++ b/sammo.py
@@ -4,6 +4,7 @@ __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from .src.gui.session import SammoActionSession
+from .src.gui.onOffEffort import SammoActionOnOffEffort
 
 
 class Sammo:
@@ -11,10 +12,13 @@ class Sammo:
         self.iface = iface
         self.toolBar = self.iface.addToolBar("Sammo ToolBar")
         self.actionSession = SammoActionSession(self.iface.mainWindow(), self.toolBar)
+        self.actionOnOffSession = SammoActionOnOffEffort(self.iface, self.toolBar)
 
     def initGui(self):
         self.actionSession.initGui()
+        self.actionOnOffSession.initGui()
 
     def unload(self):
         self.actionSession.unload()
+        self.actionOnOffSession.unload()
         del self.toolBar

--- a/sammo.py
+++ b/sammo.py
@@ -5,14 +5,24 @@ __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from .src.gui.session import SammoActionSession
 from .src.gui.onOffEffort import SammoActionOnOffEffort
+from .src.core.session import SammoSession
 
 
 class Sammo:
     def __init__(self, iface):
         self.iface = iface
         self.toolBar = self.iface.addToolBar("Sammo ToolBar")
-        self.actionSession = SammoActionSession(self.iface.mainWindow(), self.toolBar)
-        self.actionOnOffSession = SammoActionOnOffEffort(self.iface, self.toolBar)
+        self.session = SammoSession()
+        self.actionSession = SammoActionSession(
+            self.iface.mainWindow(),
+            self.toolBar,
+            self.session
+        )
+        self.actionOnOffSession = SammoActionOnOffEffort(
+            self.iface,
+            self.toolBar,
+            self.session
+        )
 
     def initGui(self):
         self.actionSession.initGui()

--- a/sammo.py
+++ b/sammo.py
@@ -11,13 +11,13 @@ from .src.core.session import SammoSession
 class Sammo(ParentOfSammoActionSession):
     def __init__(self, iface):
         self.iface = iface
-        self.sammoToolBar = self.iface.addToolBar("Sammo ToolBar")
-        self.sammoSession = SammoSession()
+        self._toolBar = self.iface.addToolBar("Sammo ToolBar")
+        self._session = SammoSession()
         self.actionSession = SammoActionSession(self)
         self.actionOnOffSession = SammoActionOnOffEffort(
             self.iface,
-            self.sammoToolBar,
-            self.sammoSession
+            self._toolBar,
+            self._session
         )
 
     def initGui(self):
@@ -27,7 +27,7 @@ class Sammo(ParentOfSammoActionSession):
     def unload(self):
         self.actionSession.unload()
         self.actionOnOffSession.unload()
-        del self.sammoToolBar
+        del self._toolBar
 
     def onCreateSession(self):
         self.actionOnOffSession.onCreateSession()
@@ -38,8 +38,8 @@ class Sammo(ParentOfSammoActionSession):
 
     @property
     def toolBar(self):
-        return self.sammoToolBar
+        return self._toolBar
 
     @property
     def session(self):
-        return self.sammoSession
+        return self._session

--- a/sammo.py
+++ b/sammo.py
@@ -29,10 +29,13 @@ class Sammo(ParentOfSammoActionSession, ParentOfSammoActionOnOffEffort):
         self._session.onCreateSession(workingDirectory)
         self.actionOnOffSession.onCreateSession()
 
-    def openDialogToAddNewFeatureToEnvironmentTable(self):
+    def OnStartEffort(self):
         [feat, table] = self._session.getReadyToAddNewFeatureToEnvironmentTable()
         if self.iface.openFeatureForm(table, feat):
             self._session.addNewFeatureToEnvironmentTable(feat)
+
+    def OnStopEffort(self):
+        self._session.onStopEffort()
 
     @property
     def mainWindow(self):

--- a/sammo.py
+++ b/sammo.py
@@ -4,21 +4,17 @@ __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from .src.gui.session import SammoActionSession, ParentOfSammoActionSession
-from .src.gui.onOffEffort import SammoActionOnOffEffort
+from .src.gui.onOffEffort import SammoActionOnOffEffort, ParentOfSammoActionOnOffEffort
 from .src.core.session import SammoSession
 
 
-class Sammo(ParentOfSammoActionSession):
+class Sammo(ParentOfSammoActionSession, ParentOfSammoActionOnOffEffort):
     def __init__(self, iface):
         self.iface = iface
         self._toolBar = self.iface.addToolBar("Sammo ToolBar")
         self._session = SammoSession()
         self.actionSession = SammoActionSession(self)
-        self.actionOnOffSession = SammoActionOnOffEffort(
-            self.iface,
-            self._toolBar,
-            self._session
-        )
+        self.actionOnOffSession = SammoActionOnOffEffort(self)
 
     def initGui(self):
         self.actionSession.initGui()
@@ -29,8 +25,14 @@ class Sammo(ParentOfSammoActionSession):
         self.actionOnOffSession.unload()
         del self._toolBar
 
-    def onCreateSession(self):
+    def onCreateSession(self, workingDirectory : str):
+        self._session.onCreateSession(workingDirectory)
         self.actionOnOffSession.onCreateSession()
+
+    def openDialogToAddNewFeatureToEnvironmentTable(self):
+        [feat, table] = self._session.getReadyToAddNewFeatureToEnvironmentTable()
+        if self.iface.openFeatureForm(table, feat):
+            self._session.addNewFeatureToEnvironmentTable(feat)
 
     @property
     def mainWindow(self):

--- a/sammo.py
+++ b/sammo.py
@@ -3,25 +3,21 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
-from .src.gui.session import SammoActionSession
+from .src.gui.session import SammoActionSession, ParentOfSammoActionSession
 from .src.gui.onOffEffort import SammoActionOnOffEffort
 from .src.core.session import SammoSession
 
 
-class Sammo:
+class Sammo(ParentOfSammoActionSession):
     def __init__(self, iface):
         self.iface = iface
-        self.toolBar = self.iface.addToolBar("Sammo ToolBar")
-        self.session = SammoSession()
-        self.actionSession = SammoActionSession(
-            self.iface.mainWindow(),
-            self.toolBar,
-            self.session
-        )
+        self.sammoToolBar = self.iface.addToolBar("Sammo ToolBar")
+        self.sammoSession = SammoSession()
+        self.actionSession = SammoActionSession(self)
         self.actionOnOffSession = SammoActionOnOffEffort(
             self.iface,
-            self.toolBar,
-            self.session
+            self.sammoToolBar,
+            self.sammoSession
         )
 
     def initGui(self):
@@ -31,4 +27,19 @@ class Sammo:
     def unload(self):
         self.actionSession.unload()
         self.actionOnOffSession.unload()
-        del self.toolBar
+        del self.sammoToolBar
+
+    def onCreateSession(self):
+        self.actionOnOffSession.onCreateSession()
+
+    @property
+    def mainWindow(self):
+        return self.iface.mainWindow()
+
+    @property
+    def toolBar(self):
+        return self.sammoToolBar
+
+    @property
+    def session(self):
+        return self.sammoSession

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -22,6 +22,7 @@ class SammoDataBase:
     DB_NAME = "sammo-boat.gpkg"
     LAYER_NAME = "session data"
     ENVIRONMENT_TABLE_NAME = "environment"
+    ENVIRONMENT_COMMENT_FIELD_NAME = "commentaire"
 
     @staticmethod
     def isDataBaseAvailableInThisDirectory(directory):
@@ -99,10 +100,19 @@ class SammoDataBase:
         fields.append(QgsField("nebulosite", QVariant.Int))
         fields.append(self._createFieldShortText("cond_generale"))
         fields.append(QgsField("visibilité", QVariant.Double))
-        fields.append(self._createFieldShortText("commentaire"))
+        fields.append(self._createFieldShortText(SammoDataBase.ENVIRONMENT_COMMENT_FIELD_NAME))
         fields.append(self._createFieldShortText("Survey"))
 
         return fields
+
+    def getIdOfLastAddedFeature(self, layer: QgsVectorLayer):
+        maxId = -1
+        for feature in layer.getFeatures():
+            if feature.id() > maxId:
+                maxId = feature.id()
+            break
+
+        return maxId
 
     @staticmethod
     def _createFieldShortText(fieldName):

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -5,10 +5,7 @@ __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 import os.path
 
-from PyQt5.QtWidgets import QMessageBox
 from qgis.PyQt.QtCore import QVariant
-from qgis._core import QgsVectorLayer
-from qgis.core import QgsField
 from qgis.core import (
     QgsWkbTypes,
     QgsFields,
@@ -16,6 +13,8 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransformContext,
     QgsFeatureSink,
+    QgsVectorLayer,
+    QgsField
 )
 
 
@@ -49,11 +48,13 @@ class SammoDataBase:
         opts.driverName = "GPKG"
         opts.layerName = tableName
         if not os.path.isfile(db):
-            opts.actionOnExistingFile = \
+            opts.actionOnExistingFile = (
                 QgsVectorFileWriter.CreateOrOverwriteFile
+            )
         else:
-            opts.actionOnExistingFile = \
+            opts.actionOnExistingFile = (
                 QgsVectorFileWriter.CreateOrOverwriteLayer
+            )
         crs = QgsCoordinateReferenceSystem.fromEpsgId(4326)
         QgsVectorFileWriter.create(
             db,

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -21,7 +21,8 @@ LAYER_NAME = "session data"
 
 
 class SammoDataBase:
-    def isDataBaseAvailableInThisDirectory(self, directory):
+    @staticmethod
+    def isDataBaseAvailableInThisDirectory(directory):
         return os.path.isfile(SammoDataBase._pathToDataBase(directory))
 
     @property

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -5,7 +5,9 @@ __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 import os.path
 
+from PyQt5.QtWidgets import QMessageBox
 from qgis.PyQt.QtCore import QVariant
+from qgis._core import QgsVectorLayer
 from qgis.core import QgsField
 from qgis.core import (
     QgsWkbTypes,
@@ -16,22 +18,15 @@ from qgis.core import (
     QgsFeatureSink,
 )
 
-DB_NAME = "sammo-boat.gpkg"
-LAYER_NAME = "session data"
-
 
 class SammoDataBase:
+    DB_NAME = "sammo-boat.gpkg"
+    LAYER_NAME = "session data"
+    ENVIRONMENT_TABLE_NAME = "environment"
+
     @staticmethod
     def isDataBaseAvailableInThisDirectory(directory):
         return os.path.isfile(SammoDataBase._pathToDataBase(directory))
-
-    @property
-    def dbName(self):
-        return DB_NAME
-
-    @property
-    def _layerName(self):
-        return LAYER_NAME
 
     def createEmptyDataBase(self, directory):
         db = SammoDataBase._pathToDataBase(directory)
@@ -74,7 +69,7 @@ class SammoDataBase:
 
     @staticmethod
     def _pathToDataBase(directory):
-        return os.path.join(directory, DB_NAME)
+        return os.path.join(directory, SammoDataBase.DB_NAME)
 
     def _createFieldsForEnvironmentTable(self):
         fields = QgsFields()
@@ -111,3 +106,7 @@ class SammoDataBase:
     @staticmethod
     def _createFieldShortText(fieldName):
         return QgsField(fieldName, QVariant.String, len=50)
+
+    def loadTable(self, directory, tableName):
+        db = self._pathToDataBase(directory)
+        return QgsVectorLayer(db, tableName)

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -14,7 +14,7 @@ from qgis.core import (
     QgsCoordinateTransformContext,
     QgsFeatureSink,
     QgsVectorLayer,
-    QgsField
+    QgsField,
 )
 
 
@@ -32,7 +32,9 @@ class SammoDataBase:
         db = SammoDataBase._pathToDataBase(directory)
 
         SammoDataBase._addTableToDataBaseFile(
-            db, self._createFieldsForEnvironmentTable(), "environment"
+            db,
+            self._createFieldsForEnvironmentTable(),
+            SammoDataBase.ENVIRONMENT_TABLE_NAME,
         )
 
     @staticmethod
@@ -100,7 +102,11 @@ class SammoDataBase:
         fields.append(QgsField("nebulosite", QVariant.Int))
         fields.append(self._createFieldShortText("cond_generale"))
         fields.append(QgsField("visibilité", QVariant.Double))
-        fields.append(self._createFieldShortText(SammoDataBase.ENVIRONMENT_COMMENT_FIELD_NAME))
+        fields.append(
+            self._createFieldShortText(
+                SammoDataBase.ENVIRONMENT_COMMENT_FIELD_NAME
+            )
+        )
         fields.append(self._createFieldShortText("Survey"))
 
         return fields
@@ -110,7 +116,6 @@ class SammoDataBase:
         for feature in layer.getFeatures():
             if feature.id() > maxId:
                 maxId = feature.id()
-            break
 
         return maxId
 

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -15,7 +15,6 @@ class SammoSession:
         self.isDbOpened = False
         self._directoryPath: str = None
         self._environmentTable: QgsVectorLayer = None
-        self._idCurrentEnvironmentFeature = None
 
     @staticmethod
     def isDataBaseAvailable(directory):
@@ -38,31 +37,35 @@ class SammoSession:
             )
 
     def onStopEffort(self):
-        print("nb de champs = " + str(self._environmentTable.fields().count()))
-        print("self._idCurrentEnvironmentFeature = " + str(self._idCurrentEnvironmentFeature))
-        print("nb de features = " + str(self._environmentTable.featureCount()))
-        print("lastField id = " + str(self.db.getIdOfLastAddedFeature(self._environmentTable)))
         table = self._environmentTable
         table.startEditing()
-        field_idx = table.fields().indexOf(SammoDataBase.ENVIRONMENT_COMMENT_FIELD_NAME)
+        idLastAddedFeature = self.db.getIdOfLastAddedFeature(
+            self._environmentTable
+        )
+        field_idx = table.fields().indexOf(
+            SammoDataBase.ENVIRONMENT_COMMENT_FIELD_NAME
+        )
         dateTimeObj = datetime.now()
-        timeOfStopEffort = "End of the Effort at : " \
-                        + str(dateTimeObj.year) \
-                        + '/' + str(dateTimeObj.month) \
-                        + '/' + str(dateTimeObj.day) \
-                        + ' ' \
-                        + str(dateTimeObj.hour) \
-                        + ':' + str(dateTimeObj.minute) \
-                        + ':' + str(dateTimeObj.second)
+        timeOfStopEffort = (
+            "End of the Effort at : "
+            + "{:02d}".format(dateTimeObj.day)
+            + "/"
+            + "{:02d}".format(dateTimeObj.month)
+            + "/"
+            + str(dateTimeObj.year)
+            + " "
+            + "{:02d}".format(dateTimeObj.hour)
+            + ":"
+            + "{:02d}".format(dateTimeObj.minute)
+            + ":"
+            + "{:02d}".format(dateTimeObj.second)
+        )
         if not table.changeAttributeValue(
-                self._idCurrentEnvironmentFeature,
-                field_idx,
-                timeOfStopEffort
+            idLastAddedFeature, field_idx, timeOfStopEffort
             ):
             print("Echec de la modification du champs commentaire")
 
         table.commitChanges()
-        self._idCurrentEnvironmentFeature = None
 
     def createEmptyDataBase(self, directory):
         self.db.createEmptyDataBase(directory)
@@ -76,7 +79,6 @@ class SammoSession:
     def addNewFeatureToEnvironmentTable(self, feat):
         self._environmentTable.addFeature(feat)
         self._environmentTable.commitChanges()
-        self._idCurrentEnvironmentFeature = feat.id()
 
     def _getReadyToAddNewFeature(self, table: QgsVectorLayer):
         feat = QgsVectorLayerUtils.createFeature(table)

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -13,14 +13,9 @@ class SammoSession:
         self.isDbOpened = False
         self.directoryPath = None
 
-    def isDataBaseAvailable(self, directory):
-        return self.db.isDataBaseAvailableInThisDirectory(directory)
+    @staticmethod
+    def isDataBaseAvailable(directory):
+        return SammoDataBase.isDataBaseAvailableInThisDirectory(directory)
 
     def createEmptyDataBase(self, directory):
         self.db.createEmptyDataBase(directory)
-
-    def isDataBaseLayerExistsInCurrentProject(self):
-        db_layers = QgsProject.instance().mapLayersByName(
-            SammoDataBase.dbName
-        )
-        return len(db_layers) != 0

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -25,12 +25,14 @@ class SammoSession:
             # No geopackage DB in this directory
             self.createEmptyDataBase(directory)
 
-        self._environmentTable = self.loadTable(SammoDataBase.ENVIRONMENT_TABLE_NAME)
+        self._environmentTable = self.loadTable(
+            SammoDataBase.ENVIRONMENT_TABLE_NAME
+        )
         if not self._environmentTable.isValid():
             QMessageBox.critical(
                 None,
                 "Sammo-Boat plugin",
-                "Impossible to read the environment table "
+                "Impossible to read the environment table ",
             )
 
     def createEmptyDataBase(self, directory):
@@ -46,7 +48,7 @@ class SammoSession:
         self._environmentTable.addFeature(feat)
         self._environmentTable.commitChanges()
 
-    def _getReadyToAddNewFeature(self, table : QgsVectorLayer):
+    def _getReadyToAddNewFeature(self, table: QgsVectorLayer):
         feat = QgsVectorLayerUtils.createFeature(table)
         table.startEditing()
 

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -3,7 +3,6 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
-from qgis.core import QgsProject
 from .database import SammoDataBase
 
 
@@ -19,3 +18,6 @@ class SammoSession:
 
     def createEmptyDataBase(self, directory):
         self.db.createEmptyDataBase(directory)
+
+    def loadTable(self, tableName):
+        return self.db.loadTable(self.directoryPath, tableName)

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -5,42 +5,48 @@ __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from .database import SammoDataBase
 from qgis.PyQt.QtWidgets import QMessageBox
-from qgis.core import QgsVectorLayerUtils
+from qgis.core import QgsVectorLayerUtils, QgsVectorLayer
 
 
 class SammoSession:
     def __init__(self):
         self.db = SammoDataBase()
         self.isDbOpened = False
-        self.directoryPath = None
+        self._directoryPath = None
+        self._environmentTable = None
 
     @staticmethod
     def isDataBaseAvailable(directory):
         return SammoDataBase.isDataBaseAvailableInThisDirectory(directory)
 
+    def onCreateSession(self, directory):
+        self._directoryPath = directory
+        if not self.isDataBaseAvailable(directory):
+            # No geopackage DB in this directory
+            self.createEmptyDataBase(directory)
+
+        self._environmentTable = self.loadTable(SammoDataBase.ENVIRONMENT_TABLE_NAME)
+        if not self._environmentTable.isValid():
+            QMessageBox.critical(
+                None,
+                "Sammo-Boat plugin",
+                "Impossible to read the environment table "
+            )
+
     def createEmptyDataBase(self, directory):
         self.db.createEmptyDataBase(directory)
 
     def loadTable(self, tableName):
-        return self.db.loadTable(self.directoryPath, tableName)
+        return self.db.loadTable(self._directoryPath, tableName)
 
     def getReadyToAddNewFeatureToEnvironmentTable(self):
-        return self._getReadyToAddNewFeature(SammoDataBase.ENVIRONMENT_TABLE_NAME)
+        return self._getReadyToAddNewFeature(self._environmentTable)
 
-    def addNewFeatureToEnvironmentTable(self, table, feat):
-        table.addFeature(feat)
-        table.commitChanges()
+    def addNewFeatureToEnvironmentTable(self, feat):
+        self._environmentTable.addFeature(feat)
+        self._environmentTable.commitChanges()
 
-    def _getReadyToAddNewFeature(self, tableName):
-        table = self.loadTable(tableName)
-        if not table.isValid():
-            QMessageBox.critical(
-                None,
-                "Sammo-Boat plugin",
-                "Impossible to read the table " + tableName
-            )
-            return
-
+    def _getReadyToAddNewFeature(self, table : QgsVectorLayer):
         feat = QgsVectorLayerUtils.createFeature(table)
         table.startEditing()
 

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -4,6 +4,8 @@ __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from .database import SammoDataBase
+from qgis.PyQt.QtWidgets import QMessageBox
+from qgis.core import QgsVectorLayerUtils
 
 
 class SammoSession:
@@ -21,3 +23,25 @@ class SammoSession:
 
     def loadTable(self, tableName):
         return self.db.loadTable(self.directoryPath, tableName)
+
+    def getReadyToAddNewFeatureToEnvironmentTable(self):
+        return self._getReadyToAddNewFeature(SammoDataBase.ENVIRONMENT_TABLE_NAME)
+
+    def addNewFeatureToEnvironmentTable(self, table, feat):
+        table.addFeature(feat)
+        table.commitChanges()
+
+    def _getReadyToAddNewFeature(self, tableName):
+        table = self.loadTable(tableName)
+        if not table.isValid():
+            QMessageBox.critical(
+                None,
+                "Sammo-Boat plugin",
+                "Impossible to read the table " + tableName
+            )
+            return
+
+        feat = QgsVectorLayerUtils.createFeature(table)
+        table.startEditing()
+
+        return [feat, table]

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -43,6 +43,6 @@ class SammoActionOnOffEffort:
             )
             return
 
-        feat = QgsFeature();
-        feat.setFields(table.fields())
-        self.iface.openFeatureForm(table, feat)
+        print("Form creation")
+        feat = QgsFeature(table.fields());
+        self.iface.openFeatureForm(table, feat, False)

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -3,26 +3,43 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
+from abc import abstractmethod
 from qgis.PyQt.QtWidgets import QPushButton
 
-from ..core.database import SammoDataBase
+
+class ParentOfSammoActionOnOffEffort:
+    """
+    This is the abstract class that Sammo class
+    (which is the owner of the SammoActionOnOffEffort
+    instance) needs to inherit from
+    """
+
+    @property
+    @abstractmethod
+    def mainWindow(self):
+        pass
+
+    @property
+    @abstractmethod
+    def toolBar(self):
+        pass
+
+    @abstractmethod
+    def openDialogToAddNewFeatureToEnvironmentTable(self):
+        pass
 
 
 class SammoActionOnOffEffort:
-    def __init__(self, iface, toolBar, session):
-        self.iface = iface
-        self.mainWindow = self.iface.mainWindow()
-        self.action = None
-        self.session = session
-        self.toolBar = toolBar
+    def __init__(self, parent : ParentOfSammoActionOnOffEffort):
+        self.parent = parent
         self.button = None
 
     def initGui(self):
-        self.button = QPushButton(self.mainWindow)
+        self.button = QPushButton(self.parent.mainWindow)
         self.button.setText("Effort")
         self.button.clicked.connect(self.run)
         self.button.setEnabled(False)
-        self.toolBar.addWidget(self.button)
+        self.parent.toolBar.addWidget(self.button)
 
     def onCreateSession(self):
         self.button.setEnabled(True)
@@ -31,9 +48,4 @@ class SammoActionOnOffEffort:
         del self.button
 
     def run(self):
-        print("Effort button pressed")
-
-        [feat, table] = self.session.getReadyToAddNewFeatureToEnvironmentTable()
-        if self.iface.openFeatureForm(table, feat):
-            self.session.addNewFeatureToEnvironmentTable(table, feat)
-
+        self.parent.openDialogToAddNewFeatureToEnvironmentTable()

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -1,0 +1,29 @@
+# coding: utf8
+
+__contact__ = "info@hytech-imaging.fr"
+__copyright__ = "Copyright (c) 2021 Hytech Imaging"
+
+
+from qgis.PyQt.QtCore import QDir
+from qgis.PyQt.QtWidgets import QAction, QFileDialog
+from ..core.session import SammoSession
+
+
+class SammoActionOnOffEffort:
+    def __init__(self, iface, toolBar):
+        self.iface = iface
+        self.mainWindow = self.iface.mainWindow()
+        self.action = None
+        self.session = SammoSession()
+        self.toolBar = toolBar
+
+    def initGui(self):
+        self.action = QAction("Effort", self.mainWindow)
+        self.action.triggered.connect(self.run)
+        self.toolBar.addAction(self.action)
+
+    def unload(self):
+        del self.action
+
+    def run(self):
+        print("Effort button pressed")

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -3,18 +3,19 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
+from qgis.PyQt.QtWidgets import QMessageBox, QAction
+from qgis._core import QgsFeature
 
-from qgis.PyQt.QtCore import QDir
-from qgis.PyQt.QtWidgets import QAction, QFileDialog
 from ..core.session import SammoSession
+from ..core.database import SammoDataBase
 
 
 class SammoActionOnOffEffort:
-    def __init__(self, iface, toolBar):
+    def __init__(self, iface, toolBar, session):
         self.iface = iface
         self.mainWindow = self.iface.mainWindow()
         self.action = None
-        self.session = SammoSession()
+        self.session = session
         self.toolBar = toolBar
 
     def initGui(self):
@@ -27,3 +28,15 @@ class SammoActionOnOffEffort:
 
     def run(self):
         print("Effort button pressed")
+        table = self.session.loadTable(SammoDataBase.ENVIRONMENT_TABLE_NAME)
+        if not table.isValid():
+            QMessageBox.critical(
+                None,
+                "Sammo-Boat plugin",
+                "Impossible to read the environment table "
+            )
+            return
+
+        feat = QgsFeature();
+        feat.setFields(table.fields())
+        self.iface.openFeatureForm(table, feat)

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -30,7 +30,7 @@ class ParentOfSammoActionOnOffEffort:
 
 
 class SammoActionOnOffEffort:
-    def __init__(self, parent : ParentOfSammoActionOnOffEffort):
+    def __init__(self, parent: ParentOfSammoActionOnOffEffort):
         self.parent = parent
         self.button = None
 

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -3,10 +3,9 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
-from qgis.PyQt.QtWidgets import QMessageBox, QAction, QPushButton
-from qgis.core import QgsFeature
+from qgis.PyQt.QtWidgets import QMessageBox, QPushButton
+from qgis.core import QgsVectorLayerUtils
 
-from ..core.session import SammoSession
 from ..core.database import SammoDataBase
 
 
@@ -43,6 +42,9 @@ class SammoActionOnOffEffort:
             )
             return
 
-        print("Form creation")
-        feat = QgsFeature(table.fields());
-        self.iface.openFeatureForm(table, feat, False)
+        feat = QgsVectorLayerUtils.createFeature(table)
+        table.startEditing()
+        if self.iface.openFeatureForm(table, feat):
+            table.addFeature(feat)
+            table.commitChanges()
+

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -3,8 +3,8 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
-from qgis.PyQt.QtWidgets import QMessageBox, QAction
-from qgis._core import QgsFeature
+from qgis.PyQt.QtWidgets import QMessageBox, QAction, QPushButton
+from qgis.core import QgsFeature
 
 from ..core.session import SammoSession
 from ..core.database import SammoDataBase
@@ -17,14 +17,20 @@ class SammoActionOnOffEffort:
         self.action = None
         self.session = session
         self.toolBar = toolBar
+        self.button = None
 
     def initGui(self):
-        self.action = QAction("Effort", self.mainWindow)
-        self.action.triggered.connect(self.run)
-        self.toolBar.addAction(self.action)
+        self.button = QPushButton(self.mainWindow)
+        self.button.setText("Effort")
+        self.button.clicked.connect(self.run)
+        self.button.setEnabled(False)
+        self.toolBar.addWidget(self.button)
+
+    def onCreateSession(self):
+        self.button.setEnabled(True)
 
     def unload(self):
-        del self.action
+        del self.button
 
     def run(self):
         print("Effort button pressed")

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -3,8 +3,7 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
-from qgis.PyQt.QtWidgets import QMessageBox, QPushButton
-from qgis.core import QgsVectorLayerUtils
+from qgis.PyQt.QtWidgets import QPushButton
 
 from ..core.database import SammoDataBase
 
@@ -33,18 +32,8 @@ class SammoActionOnOffEffort:
 
     def run(self):
         print("Effort button pressed")
-        table = self.session.loadTable(SammoDataBase.ENVIRONMENT_TABLE_NAME)
-        if not table.isValid():
-            QMessageBox.critical(
-                None,
-                "Sammo-Boat plugin",
-                "Impossible to read the environment table "
-            )
-            return
 
-        feat = QgsVectorLayerUtils.createFeature(table)
-        table.startEditing()
+        [feat, table] = self.session.getReadyToAddNewFeatureToEnvironmentTable()
         if self.iface.openFeatureForm(table, feat):
-            table.addFeature(feat)
-            table.commitChanges()
+            self.session.addNewFeatureToEnvironmentTable(table, feat)
 

--- a/src/gui/onOffEffort.py
+++ b/src/gui/onOffEffort.py
@@ -25,7 +25,11 @@ class ParentOfSammoActionOnOffEffort:
         pass
 
     @abstractmethod
-    def openDialogToAddNewFeatureToEnvironmentTable(self):
+    def OnStartEffort(self):
+        pass
+
+    @abstractmethod
+    def OnStopEffort(self):
         pass
 
 
@@ -39,6 +43,7 @@ class SammoActionOnOffEffort:
         self.button.setText("Effort")
         self.button.clicked.connect(self.run)
         self.button.setEnabled(False)
+        self.button.setCheckable(True)
         self.parent.toolBar.addWidget(self.button)
 
     def onCreateSession(self):
@@ -48,4 +53,7 @@ class SammoActionOnOffEffort:
         del self.button
 
     def run(self):
-        self.parent.openDialogToAddNewFeatureToEnvironmentTable()
+        if self.button.isChecked():
+            self.parent.OnStartEffort()
+        else:
+            self.parent.OnStopEffort()

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -36,7 +36,7 @@ class ParentOfSammoActionSession:
 
 
 class SammoActionSession:
-    def __init__(self, parent : ParentOfSammoActionSession):
+    def __init__(self, parent: ParentOfSammoActionSession):
         self.parent = parent
         self.action = None
 

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -9,10 +9,10 @@ from ..core.session import SammoSession
 
 
 class SammoActionSession:
-    def __init__(self, mainWindow, toolBar):
+    def __init__(self, mainWindow, toolBar, session):
         self.mainWindow = mainWindow
         self.action = None
-        self.session = SammoSession()
+        self.session = session
         self.toolBar = toolBar
 
     def initGui(self):

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -11,6 +11,11 @@ from ..core.session import SammoSession
 
 
 class ParentOfSammoActionSession:
+    """
+    This is the abstract class that Sammo class
+    (which is the owner of the SammoActionSession
+    instance) needs to inherit from
+    """
 
     @abstractmethod
     def onCreateSession(self):
@@ -30,6 +35,7 @@ class ParentOfSammoActionSession:
     @abstractmethod
     def session(self):
         pass
+
 
 class SammoActionSession:
     def __init__(self, parent : ParentOfSammoActionSession):

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -31,7 +31,7 @@ class SammoActionSession:
             # no directory selected
             return
 
-        if not self.session.isDataBaseAvailable(workingDirectory):
+        if not SammoSession.isDataBaseAvailable(workingDirectory):
             # No geopackage DB in this directory
             self.session.createEmptyDataBase(workingDirectory)
 

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -4,10 +4,8 @@ __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
 from abc import abstractmethod
-
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtWidgets import QAction, QFileDialog
-from ..core.session import SammoSession
 
 
 class ParentOfSammoActionSession:
@@ -58,9 +56,4 @@ class SammoActionSession:
             # no directory selected
             return
 
-        if not SammoSession.isDataBaseAvailable(workingDirectory):
-            # No geopackage DB in this directory
-            self.parent.session.createEmptyDataBase(workingDirectory)
-
-        self.parent.session.directoryPath = workingDirectory
-        self.parent.onCreateSession()
+        self.parent.onCreateSession(workingDirectory)

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -3,22 +3,43 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
+from abc import abstractmethod
+
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtWidgets import QAction, QFileDialog
 from ..core.session import SammoSession
 
 
+class ParentOfSammoActionSession:
+
+    @abstractmethod
+    def onCreateSession(self):
+        pass
+
+    @property
+    @abstractmethod
+    def mainWindow(self):
+        pass
+
+    @property
+    @abstractmethod
+    def toolBar(self):
+        pass
+
+    @property
+    @abstractmethod
+    def session(self):
+        pass
+
 class SammoActionSession:
-    def __init__(self, mainWindow, toolBar, session):
-        self.mainWindow = mainWindow
+    def __init__(self, parent : ParentOfSammoActionSession):
+        self.parent = parent
         self.action = None
-        self.session = session
-        self.toolBar = toolBar
 
     def initGui(self):
-        self.action = QAction("Session", self.mainWindow)
+        self.action = QAction("Session", self.parent.mainWindow)
         self.action.triggered.connect(self.run)
-        self.toolBar.addAction(self.action)
+        self.parent.toolBar.addAction(self.action)
 
     def unload(self):
         del self.action
@@ -33,6 +54,7 @@ class SammoActionSession:
 
         if not SammoSession.isDataBaseAvailable(workingDirectory):
             # No geopackage DB in this directory
-            self.session.createEmptyDataBase(workingDirectory)
+            self.parent.session.createEmptyDataBase(workingDirectory)
 
-        self.session.directoryPath = workingDirectory
+        self.parent.session.directoryPath = workingDirectory
+        self.parent.onCreateSession()


### PR DESCRIPTION
- What if the user don'f fill the initial environment feature (ex : CANCEL to go outside form) ? I propose to show a message explaining that the session can't start
- I made a real button for "Effort" in order to change is properties (2 states) - To be similar, I propose to do the same for "Session" button
- I need the id of the environment feature to modify the comment field at the end of the effort : I didn't manage to save the real id of the environment feature when created. So I just took the maximum id in the features of the environment table (cf. def getIdOfLastAddedFeature (self, table: QgsVectorLayer) in database.py). There is probably a more elegant way ...
