### PR TITLE
Side field in sighting form FIX #71

### DIFF
--- a/src/core/session.py
+++ b/src/core/session.py
@@ -207,9 +207,7 @@ class SammoSession:
         cfg["map"] = [
             {"L": "L"},
             {"R": "R"},
-            {"B": "B"},
             {"C": "C"},
-            {"O": "O"},
         ]
         setup = QgsEditorWidgetSetup("ValueMap", cfg)
         layer.setEditorWidgetSetup(idx, setup)


### PR DESCRIPTION
FIX #71

To merge after GPS simulation fix.

Remove B and O option in sighting form