### PR TITLE
remove useless and maybe wrong method

### DIFF
--- a/sammo.py
+++ b/sammo.py
@@ -190,8 +190,6 @@ class Sammo:
         self.tableDock.init(
             self.session.environmentLayer, self.session.sightingsLayer
         )
-        self.tableDock.refresh(self.session.sightingsLayer)
-        self.tableDock.refresh(self.session.environmentLayer)
 
         # init simu
         if self.simuGpsAction:


### PR DESCRIPTION
@pblottiere This two lines seems useless as `init()` loads layer tables, and futhermore it seems that it is in some way the cause of the crashes I observed when I close sammo project