### PR TITLE
fix log path to avoid permission error

### DIFF
--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -3,10 +3,11 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
+from pathlib import Path
 from datetime import datetime
 from qgis.core import QgsMessageLog
 
-LOG_FILE_NAME = "Sammo.log"
+LOG_FILE_NAME = (Path(__file__).parent.parent.parent / "Sammo.log").as_posix()
 
 
 class Logger:


### PR DESCRIPTION
@pblottiere

On Windows I get some error due to folder permissions. We write `Sammo.log` in the folder from where QGIS is launched and this folder can be protected. To avoid it, we should create Sammo.log in the plugin main folder.