### PR TITLE
add new fields + show no null constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Undo / redo mechanisms
 - Export : sightings layer is exported with joined fields of species table
 - Export : environment layer is exported with joined fields of observer table (for left/right/center observer)
+- `speed` and `course` field in environment table
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict duplication of the last entity in followers table in a same dialog
 - `species` field changed to lineEdit instead of comboBox in followers table
 - Export : X/Y field renamed Lat/Lon
+- Conditional style on null forbidden field
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Undo / redo mechanisms
 - Export : sightings layer is exported with joined fields of species table
 - Export : environment layer is exported with joined fields of observer table (for left/right/center observer)
-- `speed` and `course` field in environment table
+- `speed` and `course` fields in environment table
 
 ### Modified
 

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -94,6 +94,8 @@ class SammoDataBase:
         fields.append(self._createFieldShortText("status"))
         fields.append(self._createFieldShortText("plateform"))
         fields.append(self._createFieldShortText("routeType"))
+        fields.append(QgsField("speed", QVariant.Int))
+        fields.append(QgsField("courseAverage", QVariant.Int))
         fields.append(QgsField("seaState", QVariant.Int))
         fields.append(QgsField("windDirection", QVariant.Int))
         fields.append(QgsField("windForce", QVariant.Int))

--- a/src/core/layers/environment.py
+++ b/src/core/layers/environment.py
@@ -63,6 +63,32 @@ class SammoEnvironmentLayer(SammoLayer):
         setup = QgsEditorWidgetSetup("ValueMap", cfg)
         layer.setEditorWidgetSetup(idx, setup)
 
+        # speed
+        idx = layer.fields().indexFromName("speed")
+        cfg = {
+            "AllowNull": False,
+            "Max": 30,
+            "Min": 0,
+            "Precision": 0,
+            "Step": 1,
+            "Style": "SpinBox",
+        }
+        setup = QgsEditorWidgetSetup("Range", cfg)
+        layer.setEditorWidgetSetup(idx, setup)
+
+        # course
+        idx = layer.fields().indexFromName("courseAverage")
+        cfg = {
+            "AllowNull": False,
+            "Max": 360,
+            "Min": 1,
+            "Precision": 0,
+            "Step": 1,
+            "Style": "SpinBox",
+        }
+        setup = QgsEditorWidgetSetup("Range", cfg)
+        layer.setEditorWidgetSetup(idx, setup)
+
         # sea state
         idx = layer.fields().indexFromName("seaState")
         cfg = {
@@ -302,6 +328,12 @@ class SammoEnvironmentLayer(SammoLayer):
             layer.setEditorWidgetSetup(idx, setup)
 
     def _init_conditional_style(self, layer: QgsVectorLayer) -> None:
+        expr = "@value is NULL"
+        style = QgsConditionalStyle(expr)
+        style.setBackgroundColor(QColor("orange"))
+        for fieldName in ["routeType", "speed", "courseAverage"]:
+            layer.conditionalStyles().setFieldStyles(fieldName, [style])
+
         # glareFrom
         expr = "if (\"glareSever\" = 'none', @value != 0, False)"
         style = QgsConditionalStyle(expr)

--- a/src/core/layers/environment.py
+++ b/src/core/layers/environment.py
@@ -328,6 +328,7 @@ class SammoEnvironmentLayer(SammoLayer):
             layer.setEditorWidgetSetup(idx, setup)
 
     def _init_conditional_style(self, layer: QgsVectorLayer) -> None:
+        # routeType, speed, courseAverage
         expr = "@value is NULL"
         style = QgsConditionalStyle(expr)
         style.setBackgroundColor(QColor("orange"))

--- a/src/core/layers/followers.py
+++ b/src/core/layers/followers.py
@@ -164,3 +164,8 @@ class SammoFollowersLayer(SammoLayer):
         style = QgsConditionalStyle(expr)
         style.setBackgroundColor(QColor("orange"))
         layer.conditionalStyles().setFieldStyles("species", [style])
+
+        # podSize
+        style = QgsConditionalStyle("@value is NULL")
+        style.setBackgroundColor(QColor("orange"))
+        layer.conditionalStyles().setFieldStyles("podSize", [style])

--- a/src/core/layers/sightings.py
+++ b/src/core/layers/sightings.py
@@ -249,7 +249,7 @@ class SammoSightingsLayer(SammoLayer):
         layer.setDefaultValueDefinition(idx, QgsDefaultValue("''"))
 
     def _init_conditional_style(self, layer: QgsVectorLayer) -> None:
-        #
+        # side, distance
         expr = "@value is NULL"
         style = QgsConditionalStyle(expr)
         style.setBackgroundColor(QColor("orange"))

--- a/src/core/layers/sightings.py
+++ b/src/core/layers/sightings.py
@@ -249,9 +249,16 @@ class SammoSightingsLayer(SammoLayer):
         layer.setDefaultValueDefinition(idx, QgsDefaultValue("''"))
 
     def _init_conditional_style(self, layer: QgsVectorLayer) -> None:
+        #
+        expr = "@value is NULL"
+        style = QgsConditionalStyle(expr)
+        style.setBackgroundColor(QColor("orange"))
+        for fieldName in ["side", "distance"]:
+            layer.conditionalStyles().setFieldStyles(fieldName, [style])
+
         # podSize
         style = QgsConditionalStyle(
-            '@value > "podSizeMax" or @value < "podSizeMin"'
+            '@value > "podSizeMax" or @value < "podSizeMin" or @value is NULL'
         )
         style.setBackgroundColor(QColor("orange"))
         layer.conditionalStyles().setFieldStyles("podSize", [style])
@@ -271,7 +278,11 @@ class SammoSightingsLayer(SammoLayer):
         layer.conditionalStyles().setFieldStyles("podSizeMax", [style])
 
         # angle
-        style = QgsConditionalStyle("@value > 91 and @value < 269")
+        style = QgsConditionalStyle(
+            """
+            (@value > 91 and @value < 269) or @value is NULL
+        """
+        )
         style.setBackgroundColor(QColor("orange"))
         layer.conditionalStyles().setFieldStyles("angle", [style])
 

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -247,7 +247,7 @@ class SammoSession:
                 feat["side"] = lastFeat["side"]
             if layer == self.environmentLayer or duplicate:
                 for name in lastFeat.fields().names():
-                    if name == "fid" or name == "dateTime":
+                    if name in ["fid", "dateTime", "speed", "courseAverage"]:
                         continue
                     feat[name] = lastFeat[name]
 


### PR DESCRIPTION
@pblottiere I added speed / courseAverage fields in environment layer, which are excluded from replication mechanism.

These fields need to be fulfilled, so I added QgsConditionnalStyle to show orange cell if the value is null.

Futhermore I notice, we didn't add conditionnal style on `routeType` (environment layer), `side` / `distance` (sighting layer), 'podSize' (followers table) fields.