### PR TITLE
Better effort management

### DIFF
--- a/sammo.py
+++ b/sammo.py
@@ -163,8 +163,7 @@ class Sammo:
             )["status"] != StatusCode.display(StatusCode.END):
                 self.session.addEnvironmentFeature(StatusCode.END)
                 self.tableDock.refresh(
-                    self.session.environmentLayer,
-                    self.filterExpr
+                    self.session.environmentLayer, self.filterExpr
                 )
         else:
             reader.frame.connect(self.onGpsFrame)

--- a/sammo.py
+++ b/sammo.py
@@ -156,12 +156,11 @@ class Sammo:
         if reader.receivers(reader.frame):
             reader.frame.disconnect(self.onGpsFrame)
             self.statusDock.desactivateGPS()
-            ft = self.session.environmentLayer.getFeature(
-                self.session.environmentLayer.maximumValue(0) or -1
-            )
-            if ft.isValid() and ft["status"] != StatusCode.display(
-                StatusCode.END
-            ):
+            if self.session.environmentLayer.featureCount() and next(
+                self.session.environmentLayer.getFeatures(
+                    QgsFeatureRequest().addOrderBy("dateTime", False)
+                )
+            )["status"] != StatusCode.display(StatusCode.END):
                 self.session.addEnvironmentFeature(StatusCode.END)
         else:
             reader.frame.connect(self.onGpsFrame)

--- a/sammo.py
+++ b/sammo.py
@@ -165,6 +165,10 @@ class Sammo:
                 self.tableDock.refresh(
                     self.session.environmentLayer, self.filterExpr
                 )
+        elif not (reader.worker and reader.worker._gps):
+            self.iface.messageBar().pushCritical(
+                "No GPS detected", "retry later"
+            )
         else:
             reader.frame.connect(self.onGpsFrame)
         self.saveAll()

--- a/sammo.py
+++ b/sammo.py
@@ -160,7 +160,9 @@ class Sammo:
             ft = self.session.environmentLayer.getFeature(
                 self.session.environmentLayer.maximumValue(0) or -1
             )
-            if ft.isValid() and ft["status"] != StatusCode.display(StatusCode.END):
+            if ft.isValid() and ft["status"] != StatusCode.display(
+                StatusCode.END
+            ):
                 self.session.addEnvironmentFeature(StatusCode.END)
         else:
             reader.frame.connect(self.onGpsFrame)
@@ -216,9 +218,7 @@ class Sammo:
             self.iface.addPluginToMenu("Sammo-Boat", self.shortcutAction)
 
     def initShortcuts(self) -> None:
-        self.gpsShortcut = QShortcut(
-            QKeySequence("Shift+G"), self.mainWindow
-        )
+        self.gpsShortcut = QShortcut(QKeySequence("Shift+G"), self.mainWindow)
         self.gpsShortcut.activated.connect(self.activateGPS)
         self.environmentShortcut = QShortcut(
             QKeySequence("Shift+E"), self.mainWindow
@@ -270,7 +270,7 @@ class Sammo:
         self.zoomOutShortcut.activated.connect(self.iface.mapCanvas().zoomOut)
 
     def unload(self):
-        self.activateGPS() # add End environment Status if needed
+        self.activateGPS()  # add End environment Status if needed
         self.gpsReader.stop()
 
         if self.threadSimuGps is not None and self.threadSimuGps.isProceeding:

--- a/sammo.py
+++ b/sammo.py
@@ -130,7 +130,6 @@ class Sammo:
                 self.pluginFolder(), "src", "core", "gps_simu.csv"
             )
         threadGps = ThreadSimuGps(self.session, testFilePath)
-        # threadGps.frame.connect(self.onGpsFrame)
         return [button, threadGps]
 
     def createGpsReader(self) -> SammoGpsReader:

--- a/sammo.py
+++ b/sammo.py
@@ -331,8 +331,12 @@ class Sammo:
     def validate(self) -> None:
         self.session.validate()
         self.session.saveAll()
-        self.tableDock.refresh(self.session.environmentLayer, self.filterExpr)
-        self.tableDock.refresh(self.session.sightingsLayer, self.filterExpr)
+        self.tableDock.refresh(
+            self.session.environmentLayer, self.filterExpr, False
+        )
+        self.tableDock.refresh(
+            self.session.sightingsLayer, self.filterExpr, False
+        )
 
     def onGpsFrame(
         self,

--- a/sammo.py
+++ b/sammo.py
@@ -162,6 +162,10 @@ class Sammo:
                 )
             )["status"] != StatusCode.display(StatusCode.END):
                 self.session.addEnvironmentFeature(StatusCode.END)
+                self.tableDock.refresh(
+                    self.session.environmentLayer,
+                    self.filterExpr
+                )
         else:
             reader.frame.connect(self.onGpsFrame)
         self.saveAll()

--- a/sammo.py
+++ b/sammo.py
@@ -74,6 +74,7 @@ class Sammo:
         self.statusDock.recordInterrupted.connect(
             self.soundRecordingController.interruptRecording
         )
+        self.statusDock.activateGPS.connect(self.activateGPS)
         self.tableDock = SammoTableDock(iface)
 
         iface.projectRead.connect(self.onProjectLoaded)
@@ -128,14 +129,33 @@ class Sammo:
                 self.pluginFolder(), "src", "core", "gps_simu.csv"
             )
         threadGps = ThreadSimuGps(self.session, testFilePath)
-        threadGps.frame.connect(self.onGpsFrame)
+        # threadGps.frame.connect(self.onGpsFrame)
         return [button, threadGps]
 
     def createGpsReader(self) -> SammoGpsReader:
         gps = SammoGpsReader()
-        gps.frame.connect(self.onGpsFrame)
         gps.start()
         return gps
+
+    def activateGPS(self) -> None:
+        reader = self.gpsReader
+        if (
+            os.environ.get("SAMMO_DEBUG")
+            and self.threadSerialSimuGps
+            and self.simuGpsSerialAction.button.isChecked()
+        ):
+            reader = self.threadSerialSimuGps
+        elif (
+            os.environ.get("SAMMO_DEBUG")
+            and self.threadSimuGps
+            and self.simuGpsAction.button.isChecked()
+        ):
+            reader = self.threadSimuGps
+
+        if reader.receivers(reader.frame):
+            reader.frame.disconnect(self.onGpsFrame)
+        else:
+            reader.frame.connect(self.onGpsFrame)
 
     def createSaveAction(self) -> SammoSaveAction:
         button = SammoSaveAction(self.mainWindow, self.toolbar)

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -155,6 +155,7 @@ class SammoDataBase:
         fields.append(self._createFieldShortText("soundStart"))
         fields.append(self._createFieldShortText("soundEnd"))
         fields.append(QgsField("validated", QVariant.Bool))
+        fields.append(QgsField("effortGroup", QVariant.Int))
 
         return fields
 

--- a/src/core/gps.py
+++ b/src/core/gps.py
@@ -8,7 +8,7 @@ import sys
 import time
 import serial
 import platform
-from typing import Tuple
+from typing import Tuple, Optional
 from serial import SerialException
 
 from qgis.PyQt.QtCore import pyqtSignal
@@ -23,7 +23,7 @@ class WorkerGpsExtractor(WorkerForOtherThread):
 
     def __init__(self):
         super().__init__()
-        self._gps: serial.Serial = None
+        self._gps: Optional[serial.Serial] = None
         self.isGpsOnline: bool = False
         self.isGPRMCMode: bool = False
         self.idOfPort: int = 0
@@ -146,6 +146,7 @@ class SammoGpsReader(OtherThread):
     def __init__(self):
         super().__init__()
         self.active = False
+        self.worker = None
 
     def start(self) -> None:
         self.worker = WorkerGpsExtractor()

--- a/src/core/layers/duplicate_action.py
+++ b/src/core/layers/duplicate_action.py
@@ -3,6 +3,7 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2022 Hytech Imaging"
 
+from qgis import utils
 from qgis.PyQt.QtWidgets import (
     QLabel,
     QDialog,
@@ -29,7 +30,7 @@ class DuplicateDialog(QDialog):
     ):
         super().__init__()
         self.layer: QgsVectorLayer = QgsProject.instance().mapLayer(layerId)
-        self.setWindowTitle(f"Duplicate {layer.name()} entity")
+        self.setWindowTitle(f"Duplicate {self.layer.name().lower()} entity")
         self.gpsLayer: QgsVectorLayer = gpsLayer
         self.toDuplicate: QgsFeature = self.layer.getFeature(toDuplicate)
         self.validateButton = QPushButton("Duplicate with changes")
@@ -114,6 +115,9 @@ class DuplicateDialog(QDialog):
         self.layer.commitChanges()
         self.layer.startEditing()
         self.close()
+        for pluginInstance in utils.plugins.values():
+            if pluginInstance.__class__.__name__ == 'Sammo':
+                pluginInstance.filterTable()
 
     def updateGeometry(self):
         dt = self.datetimeEdit.dateTime()

--- a/src/core/layers/duplicate_action.py
+++ b/src/core/layers/duplicate_action.py
@@ -29,6 +29,7 @@ class DuplicateDialog(QDialog):
     ):
         super().__init__()
         self.layer: QgsVectorLayer = QgsProject.instance().mapLayer(layerId)
+        self.setWindowTitle(f"Duplicate {layer.name()} entity")
         self.gpsLayer: QgsVectorLayer = gpsLayer
         self.toDuplicate: QgsFeature = self.layer.getFeature(toDuplicate)
         self.validateButton = QPushButton("Duplicate with changes")

--- a/src/core/layers/duplicate_action.py
+++ b/src/core/layers/duplicate_action.py
@@ -116,7 +116,7 @@ class DuplicateDialog(QDialog):
         self.layer.startEditing()
         self.close()
         for pluginInstance in utils.plugins.values():
-            if pluginInstance.__class__.__name__ == 'Sammo':
+            if pluginInstance.__class__.__name__ == "Sammo":
                 pluginInstance.filterTable()
 
     def updateGeometry(self):

--- a/src/core/layers/duplicate_action.py
+++ b/src/core/layers/duplicate_action.py
@@ -1,0 +1,193 @@
+# coding: utf8
+
+__contact__ = "info@hytech-imaging.fr"
+__copyright__ = "Copyright (c) 2022 Hytech Imaging"
+
+from qgis.PyQt.QtWidgets import (
+    QLabel,
+    QDialog,
+    QComboBox,
+    QPushButton,
+    QHBoxLayout,
+    QVBoxLayout,
+    QDateTimeEdit,
+)
+from qgis.core import (
+    QgsProject,
+    QgsFeature,
+    QgsGeometry,
+    QgsVectorLayer,
+    QgsGeometryUtils,
+    QgsFeatureRequest,
+    QgsVectorLayerUtils,
+)
+
+
+class DuplicateDialog(QDialog):
+    def __init__(
+        self, toDuplicate: int, layerId: str, gpsLayer: QgsVectorLayer
+    ):
+        super().__init__()
+        self.layer: QgsVectorLayer = QgsProject.instance().mapLayer(layerId)
+        self.gpsLayer: QgsVectorLayer = gpsLayer
+        self.toDuplicate: QgsFeature = self.layer.getFeature(toDuplicate)
+        self.validateButton = QPushButton("Duplicate with changes")
+        self.validateButton.clicked.connect(self.validate)
+        self.cancelButton = QPushButton("Cancel")
+        self.cancelButton.clicked.connect(self.close)
+
+        self.VLayout = QVBoxLayout(self)
+        # datetime
+        self.HLayout = QHBoxLayout()
+        self.datetimeLabel = QLabel("Datetime :")
+        self.datetimeEdit = QDateTimeEdit(self.toDuplicate["datetime"])
+        self.datetimeEdit.setDisplayFormat("dd/MM/yyyy hh:mm:ss")
+        self.HLayout.addWidget(self.datetimeLabel)
+        self.HLayout.addWidget(self.datetimeEdit)
+        self.VLayout.addLayout(self.HLayout)
+        self.geometryLabel = QLabel("")
+        self.datetimeEdit.dateTimeChanged.connect(self.updateGeometry)
+        self.VLayout.addWidget(self.geometryLabel)
+        if self.layer.name() == "Environment":
+            self.HStatusLayout = QHBoxLayout()
+            self.statusLabel = QLabel("Status :")
+            self.statusComboBox = QComboBox()
+            self.statusComboBox.addItems(
+                [
+                    [k for k in element.keys()][0]
+                    for element in self.layer.editorWidgetSetup(
+                        self.layer.fields().indexOf("status")
+                    ).config()["map"]
+                ]
+            )
+            self.statusComboBox.setCurrentIndex(
+                self.statusComboBox.findText(self.toDuplicate["status"])
+            )
+            self.HStatusLayout.addWidget(self.statusLabel)
+            self.HStatusLayout.addWidget(self.statusComboBox)
+            self.VLayout.addLayout(self.HStatusLayout)
+
+            self.HEffortLayout = QHBoxLayout()
+            self.effortLabel = QLabel("effortGroup :")
+            self.effortComboBox = QComboBox()
+            self.effortComboBox.addItems(
+                [
+                    str(element)
+                    for element in self.layer.uniqueValues(
+                        self.layer.fields().indexOf("effortGroup")
+                    )
+                ]
+            )
+            self.effortComboBox.setCurrentIndex(
+                self.effortComboBox.findText(
+                    str(self.toDuplicate["effortGroup"])
+                )
+            )
+            self.HEffortLayout.addWidget(self.effortLabel)
+            self.HEffortLayout.addWidget(self.effortComboBox)
+            self.VLayout.addLayout(self.HEffortLayout)
+
+            self.updateGeometry()
+
+        self.HBottomLayout = QHBoxLayout()
+        self.HBottomLayout.addWidget(self.cancelButton)
+        self.HBottomLayout.addWidget(self.validateButton)
+        self.VLayout.addLayout(self.HBottomLayout)
+
+    def validate(self):
+        feat = QgsVectorLayerUtils.createFeature(self.layer)
+        feat.setGeometry(self.interpolated)
+
+        for name in self.toDuplicate.fields().names():
+            if name == "fid":
+                continue
+            feat[name] = self.toDuplicate[name]
+
+        feat["datetime"] = self.datetimeEdit.dateTime()
+        if self.layer.name() == "Environment":
+            feat["status"] = self.statusComboBox.currentText()
+            feat["effortGroup"] = int(self.effortComboBox.currentText())
+
+        self.layer.startEditing()
+        self.layer.addFeature(feat)
+        self.layer.commitChanges()
+        self.layer.startEditing()
+        self.close()
+
+    def updateGeometry(self):
+        dt = self.datetimeEdit.dateTime()
+        request = QgsFeatureRequest().setFilterExpression(
+            f"datetime = to_datetime('{dt.toPyDateTime().isoformat()}')"
+        )
+        ftsExact = [ft for ft in self.gpsLayer.getFeatures(request)]
+        if ftsExact:
+            self.interpolated = ftsExact[0].geometry()
+            self.geometryLabel.setText(
+                f"Interpolated position : {self.interpolated.asWkt()}"
+            )
+            return
+
+        request = QgsFeatureRequest().setFilterExpression(
+            f"datetime <= to_datetime('{dt.toPyDateTime().isoformat()}')"
+        )
+        request = request.addOrderBy("dateTime", False)
+        ftsBefore = [ft for ft in self.gpsLayer.getFeatures(request)]
+        ftBefore = None
+        if ftsBefore:
+            ftBefore = ftsBefore[0]
+
+        request = QgsFeatureRequest().setFilterExpression(
+            f"datetime >= to_datetime('{dt.toPyDateTime().isoformat()}')"
+        )
+        request = request.addOrderBy("dateTime")
+        ftsAfter = [ft for ft in self.gpsLayer.getFeatures(request)]
+        ftAfter = None
+        if ftsAfter:
+            ftAfter = ftsAfter[0]
+
+        if not ftBefore or not ftAfter:
+            self.geometryLabel.setText(
+                "Interpolated position : datetime out of bounds"
+            )
+            self.interpolated = QgsGeometry()
+            return
+        duration = (
+            ftAfter["datetime"].toPyDateTime()
+            - ftBefore["datetime"].toPyDateTime()
+        ).total_seconds()
+        beforePercent = (
+            (
+                dt.toPyDateTime() - ftBefore["datetime"].toPyDateTime()
+            ).total_seconds()
+            / duration
+            if duration
+            else 0
+        )
+        geom1 = ftBefore.geometry()
+        geom2 = ftAfter.geometry()
+        if geom1.isNull() or geom2.isNull():
+            self.geometryLabel.setText(
+                "Interpolated position : closest record geometries are "
+                "not valid"
+            )
+            self.interpolated = QgsGeometry()
+            return
+        pt1 = geom1.asPoint()
+        pt2 = geom2.asPoint()
+
+        self.interpolated = QgsGeometry.fromPointXY(
+            QgsGeometryUtils.interpolatePointOnLine(
+                pt1.x(), pt1.y(), pt2.x(), pt2.y(), beforePercent
+            )
+        )
+        self.geometryLabel.setText(
+            f"Interpolated position : {self.interpolated.asWkt()}"
+        )
+
+
+toDuplicate = int("[%fid%]")
+layerId = "[%@layer_id%]"
+gpsLayers = QgsProject.instance().mapLayersByName("GPS")
+if gpsLayers:
+    dlg = DuplicateDialog(toDuplicate, layerId, gpsLayers[0])
+    dlg.show()

--- a/src/core/layers/duplicate_action.py
+++ b/src/core/layers/duplicate_action.py
@@ -128,7 +128,7 @@ class DuplicateDialog(QDialog):
         if ftsExact:
             self.interpolated = ftsExact[0].geometry()
             self.geometryLabel.setText(
-                f"Interpolated position : {self.interpolated.asWkt()}"
+                f"Interpolated position : {self.interpolated.asWkt(3)}"
             )
             return
 
@@ -186,7 +186,7 @@ class DuplicateDialog(QDialog):
             )
         )
         self.geometryLabel.setText(
-            f"Interpolated position : {self.interpolated.asWkt()}"
+            f"Interpolated position : {self.interpolated.asWkt(3)}"
         )
 
 

--- a/src/core/layers/environment.py
+++ b/src/core/layers/environment.py
@@ -313,6 +313,7 @@ class SammoEnvironmentLayer(SammoLayer):
             "strate",
             "length",
             "plateformHeight",
+            "effortGroup",
         ]:
             idx = layer.fields().indexFromName(field)
             form_config = layer.editFormConfig()

--- a/src/core/layers/environment.py
+++ b/src/core/layers/environment.py
@@ -23,7 +23,13 @@ from .layer import SammoLayer
 
 class SammoEnvironmentLayer(SammoLayer):
     def __init__(self, db: SammoDataBase, observersLayer: SammoLayer):
-        super().__init__(db, ENVIRONMENT_TABLE, "Environment", True)
+        super().__init__(
+            db,
+            ENVIRONMENT_TABLE,
+            "Environment",
+            soundAction=True,
+            duplicateAction=True,
+        )
         self.observersLayer = observersLayer
 
     def _init(self, layer: QgsVectorLayer):

--- a/src/core/layers/layer.py
+++ b/src/core/layers/layer.py
@@ -23,11 +23,13 @@ class SammoLayer:
         table: str,
         name: str,
         soundAction: bool = False,
+        duplicateAction: bool = False,
     ):
         self.db = db
         self.table = table
         self.name = name
         self.soundAction = soundAction
+        self.duplicateAction = duplicateAction
 
     @property
     def layer(self) -> QgsVectorLayer:
@@ -46,6 +48,8 @@ class SammoLayer:
 
         if self.soundAction:
             self.addSoundAction(layer)
+        if self.duplicateAction:
+            self.addDuplicateAction(layer)
 
         self._hideWidgetFid(layer)
         self._init(layer)
@@ -60,7 +64,6 @@ class SammoLayer:
         layer.setEditorWidgetSetup(idx, setup)
 
     def addSoundAction(self, layer: QgsVectorLayer) -> None:
-        layer.actions().clearActions()
         with open(Path(__file__).parent / "audio_action.py") as f:
             code = f.read()
         code = code.format(
@@ -77,6 +80,14 @@ class SammoLayer:
             self.db.directory,
         )
 
-        ac = QgsAction(1, "Play", code, False)
+        ac = QgsAction(1, "Play audio", code, False)
         ac.setActionScopes({"Field"})
+        layer.actions().addAction(ac)
+
+    def addDuplicateAction(self, layer: QgsVectorLayer) -> None:
+        with open(Path(__file__).parent / "duplicate_action.py") as f:
+            code = f.read()
+
+        ac = QgsAction(1, "Duplicate record", code, False)
+        ac.setActionScopes({"Field", "Entity"})
         layer.actions().addAction(ac)

--- a/src/core/layers/sightings.py
+++ b/src/core/layers/sightings.py
@@ -25,7 +25,13 @@ from .layer import SammoLayer, NULL
 
 class SammoSightingsLayer(SammoLayer):
     def __init__(self, db: SammoDataBase):
-        super().__init__(db, SIGHTINGS_TABLE, "Sightings", True)
+        super().__init__(
+            db,
+            SIGHTINGS_TABLE,
+            "Sightings",
+            soundAction=True,
+            duplicateAction=True,
+        )
 
     def _init(self, layer: QgsVectorLayer) -> None:
         self._init_symbology(layer)

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -223,8 +223,13 @@ class SammoSession:
                 self._plateformLayer,
             ]:
                 layer._init(layer.layer)
+            self.environmentLayer.actions().clearActions()
             self._environmentLayer.addSoundAction(self.environmentLayer)
+            self._environmentLayer.addDuplicateAction(self.environmentLayer)
+            self.sightingsLayer.actions().clearActions()
             self._sightingsLayer.addSoundAction(self.sightingsLayer)
+            self._sightingsLayer.addDuplicateAction(self.sightingsLayer)
+            self.followersLayer.actions().clearActions()
             self._followersLayer.addSoundAction(self.followersLayer)
             QgsSettings().setValue("qgis/enableMacros", "SessionOnly")
             self.environmentLayer.attributeValueChanged.connect(

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -232,7 +232,7 @@ class SammoSession:
             )
 
     def addEnvironmentFeature(
-        self, status: Optional[StatusCode]=None
+        self, status: Optional[StatusCode] = None
     ) -> QgsVectorLayer:
         layer = self.environmentLayer
         self._addFeature(

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -231,13 +231,17 @@ class SammoSession:
                 self.updateRouteTypeStatus
             )
 
-    def addEnvironmentFeature(self) -> QgsVectorLayer:
+    def addEnvironmentFeature(
+        self, status: Optional[StatusCode]=None
+    ) -> QgsVectorLayer:
         layer = self.environmentLayer
         self._addFeature(
             layer,
             geom=self.lastGpsInfo["geometry"],
             status=StatusCode.display(
-                StatusCode(int(bool(layer.featureCount())))
+                status
+                if status
+                else StatusCode(int(bool(layer.featureCount())))
             ),
             speed=self.lastGpsInfo["gprmc"]["speed"],
             courseAverage=self.lastGpsInfo["gprmc"]["course"],

--- a/src/core/thread_simu_gps.py
+++ b/src/core/thread_simu_gps.py
@@ -3,7 +3,9 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2021 Hytech Imaging"
 
+import serial
 from time import sleep
+from typing import Optional
 from .other_thread import WorkerForOtherThread, OtherThread
 from qgis.PyQt.QtCore import pyqtSignal
 from .session import SammoSession
@@ -20,6 +22,7 @@ class WorkerSimuGps(WorkerForOtherThread):
         indexOfNextGpsPoint: int,
     ):
         super().__init__()
+        self._gps: Optional[serial.Serial] = serial.Serial()
         self._testFilePath = testFilePath
         self._session: SammoSession = session
         self._lines = None
@@ -82,6 +85,7 @@ class ThreadSimuGps(OtherThread):
         self._testFilePath = testFilePath
         # always begins at the second line because the first is for titles
         self.indexOfNextGpsPoint: int = 1
+        self.worker = None
 
     def start(self):
         self.worker = WorkerSimuGps(

--- a/src/gui/status.py
+++ b/src/gui/status.py
@@ -27,11 +27,13 @@ KO_COLOR = "rgb(242, 186, 195)"
 class StatusWidget(QFrame, FORM_CLASS):
 
     recordInterrupted: pyqtSignal = pyqtSignal()
+    activateGPS: pyqtSignal = pyqtSignal()
 
     def __init__(self, parent):
         super().__init__(parent)
         self.setupUi(self)
         self.record.clicked.connect(self.interrupt)
+        self.gpsButton.clicked.connect(self.activateGPS)
         self.init()
 
     def updateNeedSave(self, status):
@@ -69,16 +71,14 @@ class StatusWidget(QFrame, FORM_CLASS):
     def updateGps(
         self, status, latitude="", longitude="", speed=-9999.0, course=-9999.0
     ):
-        self.gps.setStyleSheet(self._styleSheet(self.gps, status))
+        self.gpsButton.setStyleSheet(self._styleSheet(self.gpsButton, status))
         self.gpsFrame.setStyleSheet(self._styleSheet(self.gpsFrame, status))
-        self.gps.setAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-        icon = "gps_ko.png"
+        icon_path = "gps_ko.png"
         if status:
-            icon = "gps_ok.png"
+            icon_path = "gps_ok.png"
 
-        px = pixmap(icon, QSize(64, 64))
-        self.gps.setPixmap(px)
+        self.gpsButton.setIcon(icon(icon_path))
 
         if latitude and longitude:
             self.latitude.setText(f"{latitude:.4f}")
@@ -119,6 +119,7 @@ class StatusWidget(QFrame, FORM_CLASS):
 class SammoStatusDock(QDockWidget):
 
     recordInterrupted: pyqtSignal = pyqtSignal()
+    activateGPS: pyqtSignal = pyqtSignal()
 
     def __init__(self, iface, session):
         super().__init__("Sammo Status", iface.mainWindow())
@@ -226,6 +227,7 @@ class SammoStatusDock(QDockWidget):
     def _init(self, parent):
         self._widget = StatusWidget(self)
         self._widget.recordInterrupted.connect(self.recordInterrupted)
+        self._widget.activateGPS.connect(self.activateGPS)
 
         self.setVisible(False)
         self.dockLocationChanged.connect(self._saveLastLocation)

--- a/src/gui/status.py
+++ b/src/gui/status.py
@@ -153,6 +153,9 @@ class SammoStatusDock(QDockWidget):
             self.iface.removeDockWidget(self)
             self.setVisible(False)
 
+    def desactivateGPS(self):
+        self._counter500msWithoutGpsInfo = 4
+
     def refresh(self):
         if not self._widget:
             return

--- a/src/gui/ui/status.ui
+++ b/src/gui/ui/status.ui
@@ -68,26 +68,39 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="gps">
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="lineWidth">
-           <number>0</number>
+         <widget class="QPushButton" name="gpsButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="text">
            <string/>
           </property>
+          <property name="iconSize">
+           <size>
+            <width>108</width>
+            <height>108</height>
+           </size>
+          </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Minimum</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>5</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_3">


### PR DESCRIPTION
Convert GPS status dock in a button to enable/disable the GPS (also Shift+G shortcut). Stopping the gps also ends the current effort by adding and `End` status effort entity.

Futhermore a check has been added before validation to verify each `effortGroup` has a `Begin` entity and a `End` entity.

A new action has been to duplicate a row. User can define a new datetime (the point geometry will be interpolate between closest gps records). On environment table, the status and the effortGroup can be also defined to fix errors before validation