### PR TITLE
Better plateform management

### DIFF
--- a/data/boat.csv
+++ b/data/boat.csv
@@ -1,0 +1,4 @@
+name
+Thalassa
+Europe
+PourquoiPas

--- a/data/plateform.csv
+++ b/data/plateform.csv
@@ -1,0 +1,9 @@
+ship,plateform,plateformHeight
+Thalassa,deck,8
+Thalassa,bridge,14
+Thalassa,upper_bridge,16.5
+Europe,deck,4
+Europe,bridge,4
+PourquoiPas,deck,16.3
+PourquoiPas,bridge,18.6
+PourquoiPas,upper_bridge,21.6

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -3,6 +3,7 @@
 __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2022 Hytech Imaging"
 
+import csv
 import os.path
 from pathlib import Path
 
@@ -243,10 +244,19 @@ class SammoDataBase:
 
     def _populateBoatTable(self) -> None:
         boatLyr = QgsVectorLayer(self.tableUri(BOAT_TABLE), "boat", "ogr")
+        file = Path(__file__).parent.parent.parent / "data" / "boat.csv"
+        boats = []
+        if file.exists():
+            with open(file.as_posix()) as f:
+                boats = [
+                    { k: v for k, v in row.items()}
+                    for row in csv.DictReader(f)
+                ]
         boatLyr.startEditing()
-        for name in ["Thalassa", "Europe", "PourquoiPas"]:
+        for boatAttr in boats:
             ft = QgsFeature(boatLyr.fields())
-            ft["name"] = name
+            for k, v in boatAttr.items():
+                ft[k] = v
             boatLyr.addFeature(ft)
         boatLyr.commitChanges()
 
@@ -289,37 +299,22 @@ class SammoDataBase:
         plateformLyr = QgsVectorLayer(
             self.tableUri(PLATEFORM_TABLE), "plateform", "ogr"
         )
+        file = Path(__file__).parent.parent.parent / "data" / "plateform.csv"
+        plateforms = []
+        if file.exists():
+            with open(file.as_posix()) as f:
+                plateforms = [
+                    {
+                        k: (
+                            float(v)
+                            if k == "plateformHeight"
+                            else v
+                        )
+                        for k, v in row.items()
+                    }
+                    for row in csv.DictReader(f)
+                ]
         plateformLyr.startEditing()
-        plateforms = [
-            {"ship": "Thalassa", "plateform": "deck", "plateformHeight": 8.0},
-            {
-                "ship": "Thalassa",
-                "plateform": "bridge",
-                "plateformHeight": 14.0,
-            },
-            {
-                "ship": "Thalassa",
-                "plateform": "upper_bridge",
-                "plateformHeight": 16.5,
-            },
-            {"ship": "Europe", "plateform": "deck", "plateformHeight": 4.0},
-            {"ship": "Europe", "plateform": "bridge", "plateformHeight": 4.0},
-            {
-                "ship": "PourquoiPas",
-                "plateform": "deck",
-                "plateformHeight": 16.3,
-            },
-            {
-                "ship": "PourquoiPas",
-                "plateform": "bridge",
-                "plateformHeight": 18.6,
-            },
-            {
-                "ship": "PourquoiPas",
-                "plateform": "upper_bridge",
-                "plateformHeight": 21.6,
-            },
-        ]
         for plateformAttr in plateforms:
             ft = QgsFeature(plateformLyr.fields())
             for k, v in plateformAttr.items():

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -249,8 +249,7 @@ class SammoDataBase:
         if file.exists():
             with open(file.as_posix()) as f:
                 boats = [
-                    { k: v for k, v in row.items()}
-                    for row in csv.DictReader(f)
+                    {k: v for k, v in row.items()} for row in csv.DictReader(f)
                 ]
         boatLyr.startEditing()
         for boatAttr in boats:
@@ -305,11 +304,7 @@ class SammoDataBase:
             with open(file.as_posix()) as f:
                 plateforms = [
                     {
-                        k: (
-                            float(v)
-                            if k == "plateformHeight"
-                            else v
-                        )
+                        k: (float(v) if k == "plateformHeight" else v)
                         for k, v in row.items()
                     }
                     for row in csv.DictReader(f)

--- a/src/core/layers/__init__.py
+++ b/src/core/layers/__init__.py
@@ -4,6 +4,7 @@ __contact__ = "info@hytech-imaging.fr"
 __copyright__ = "Copyright (c) 2022 Hytech Imaging"
 
 from .gps import SammoGpsLayer
+from .boat import SammoBoatLayer
 from .world import SammoWorldLayer
 from .survey import SammoSurveyLayer
 from .strate import SammoStrateLayer

--- a/src/core/layers/boat.py
+++ b/src/core/layers/boat.py
@@ -1,0 +1,40 @@
+# coding: utf8
+
+__contact__ = "info@hytech-imaging.fr"
+__copyright__ = "Copyright (c) 2022 Hytech Imaging"
+
+from qgis.core import (
+    QgsVectorLayer,
+    QgsRelation,
+    QgsProject,
+)
+from ..database import (
+    SammoDataBase,
+    BOAT_TABLE,
+)
+from .layer import SammoLayer
+from .plateform import SammoPlateformLayer
+
+BOAT_RELATION = "boat_plateform"
+
+
+class SammoBoatLayer(SammoLayer):
+    def __init__(self, db: SammoDataBase, plateformLayer: SammoPlateformLayer):
+        super().__init__(db, BOAT_TABLE, "Boat")
+        self.plateformLayer = plateformLayer
+
+    def _init(self, layer: QgsVectorLayer) -> None:
+        project = QgsProject().instance()
+        relationManager = project.relationManager()
+        if BOAT_RELATION not in relationManager.relations():
+            relation = QgsRelation()
+            relation.setId(BOAT_RELATION)
+            relation.setName(BOAT_RELATION)
+            relation.setReferencedLayer(layer.id())
+            relation.setReferencingLayer(self.plateformLayer.layer.id())
+            relation.addFieldPair("ship", "name")
+            relationManager.addRelation(relation)
+        self._init_widgets(layer)
+
+    def _init_widgets(self, layer: QgsVectorLayer) -> None:
+        pass

--- a/src/core/layers/environment.py
+++ b/src/core/layers/environment.py
@@ -19,10 +19,17 @@ from ..database import (
 )
 
 from .layer import SammoLayer
+from .plateform import SammoPlateformLayer
+from .observers import SammoObserversLayer
 
 
 class SammoEnvironmentLayer(SammoLayer):
-    def __init__(self, db: SammoDataBase, observersLayer: SammoLayer):
+    def __init__(
+        self,
+        db: SammoDataBase,
+        observersLayer: SammoObserversLayer,
+        plateformLayer: SammoPlateformLayer,
+    ):
         super().__init__(
             db,
             ENVIRONMENT_TABLE,
@@ -31,6 +38,7 @@ class SammoEnvironmentLayer(SammoLayer):
             duplicateAction=True,
         )
         self.observersLayer = observersLayer
+        self.plateformLayer = plateformLayer
 
     def _init(self, layer: QgsVectorLayer):
         self._init_symbology(layer)
@@ -48,20 +56,28 @@ class SammoEnvironmentLayer(SammoLayer):
 
     def _init_widgets(self, layer: QgsVectorLayer) -> None:
         # platform
-        idx = layer.fields().indexFromName("plateform")
-        cfg = {}
-        cfg["map"] = [
-            {"bridge_inside": "bridge_inside"},
-            {"bridge_outside": "bridge_outside"},
-            {"upper_bridge_outside": "upper_bridge_outside"},
-            {"upper_bridge_inside": "upper_bridge_inside"},
-            {"deck": "deck"},
-        ]
-        setup = QgsEditorWidgetSetup("ValueMap", cfg)
+        idx = layer.fields().indexFromName("plateformId")
+        cfg = {
+            "AllowMulti": False,
+            "AllowNull": True,
+            "Description": "plateform",
+            "FilterExpression": " current_value('shipName') =  \"ship\" ",
+            "Key": "fid",
+            "Layer": self.plateformLayer.layer.id(),
+            "LayerName": self.plateformLayer.name,
+            "LayerProviderName": "ogr",
+            "LayerSource": self.plateformLayer.uri,
+            "NofColumns": 1,
+            "OrderByValue": False,
+            "UseCompleter": False,
+            "Value": "plateform",
+        }
+        setup = QgsEditorWidgetSetup("ValueRelation", cfg)
         layer.setEditorWidgetSetup(idx, setup)
         form_config = layer.editFormConfig()
         form_config.setReadOnly(idx, False)
         layer.setEditFormConfig(form_config)
+        layer.setFieldAlias(idx, "plateform")
 
         # route type
         idx = layer.fields().indexFromName("routeType")

--- a/src/core/layers/plateform.py
+++ b/src/core/layers/plateform.py
@@ -46,11 +46,13 @@ class SammoPlateformLayer(SammoLayer):
 
         # plateform
         idx = layer.fields().indexFromName("plateformHeight")
-        cfg = {}
-        cfg["map"] = [
-            {"8": 8},
-            {"14": 14},
-            {"16": 16},
-        ]
-        setup = QgsEditorWidgetSetup("ValueMap", cfg)
+        cfg = {
+            "AllowNull": False,
+            "Max": 1000,
+            "Min": 0,
+            "Precision": 1,
+            "Step": 1,
+            "Style": "SpinBox",
+        }
+        setup = QgsEditorWidgetSetup("Range", cfg)
         layer.setEditorWidgetSetup(idx, setup)

--- a/src/core/layers/survey.py
+++ b/src/core/layers/survey.py
@@ -10,11 +10,13 @@ from ..database import (
     SammoDataBase,
 )
 from .layer import SammoLayer
+from .boat import SammoBoatLayer
 
 
 class SammoSurveyLayer(SammoLayer):
-    def __init__(self, db: SammoDataBase):
+    def __init__(self, db: SammoDataBase, boatLayer: SammoBoatLayer):
         super().__init__(db, SURVEY_TABLE, "Survey")
+        self.boatLayer = boatLayer
 
     def _init(self, layer: QgsVectorLayer) -> None:
         self._init_widgets(layer)
@@ -44,19 +46,29 @@ class SammoSurveyLayer(SammoLayer):
             {"JUVENA": "JUVENA"},
             {"CGFS": "CGFS"},
             {"EVHOE": "EVHOE"},
+            {"MOOSE": "MOOSE"},
         ]
         setup = QgsEditorWidgetSetup("ValueMap", cfg)
         layer.setEditorWidgetSetup(idx, setup)
 
         # shipName
         idx = layer.fields().indexFromName("shipName")
-        cfg = {}
-        cfg["map"] = [
-            {"Thalassa": "Thalassa"},
-            {"Europe": "Europe"},
-            {"PourquoiPas": "PourquoiPas"},
-        ]
-        setup = QgsEditorWidgetSetup("ValueMap", cfg)
+        cfg = {
+            "AllowMulti": False,
+            "AllowNull": False,
+            "Description": '"shipName"',
+            "FilterExpression": "",
+            "Key": "name",
+            "Layer": self.boatLayer.layer.id(),
+            "LayerName": self.boatLayer.name,
+            "LayerProviderName": "ogr",
+            "LayerSource": self.boatLayer.uri,
+            "NofColumns": 1,
+            "OrderByValue": False,
+            "UseCompleter": False,
+            "Value": "name",
+        }
+        setup = QgsEditorWidgetSetup("ValueRelation", cfg)
         layer.setEditorWidgetSetup(idx, setup)
 
         # session

--- a/src/gui/export.py
+++ b/src/gui/export.py
@@ -100,12 +100,21 @@ class SammoExportAction(QDialog):
                     self.session.observersLayer.source(),
                     self.session.observersLayer.name(),
                 )  # keepped alive until export is done
-                layer.addJoin(self.environmentLayerJoinInfo(joinLayer, "left"))
                 layer.addJoin(
-                    self.environmentLayerJoinInfo(joinLayer, "rigth")
+                    self.environmentLayerJoinObserverInfo(joinLayer, "left")
                 )
                 layer.addJoin(
-                    self.environmentLayerJoinInfo(joinLayer, "center")
+                    self.environmentLayerJoinObserverInfo(joinLayer, "rigth")
+                )
+                layer.addJoin(
+                    self.environmentLayerJoinObserverInfo(joinLayer, "center")
+                )
+                joinLayer = QgsVectorLayer(
+                    self.session.plateformLayer.source(),
+                    self.session.plateformLayer.name(),
+                )
+                layer.addJoin(
+                    self.environmentLayerJoinPlateformInfo(joinLayer)
                 )
 
             options = QgsVectorFileWriter.SaveVectorOptions()
@@ -113,7 +122,7 @@ class SammoExportAction(QDialog):
             options.attributes = [
                 layer.fields().indexOf(field.name())
                 for field in layer.fields()
-                if field.name() != "validated"
+                if field.name() not in ["validated", "plateformId"]
             ]
             QgsVectorFileWriter.writeAsVectorFormatV2(
                 layer,
@@ -138,7 +147,7 @@ class SammoExportAction(QDialog):
         )
         return joinInfo
 
-    def environmentLayerJoinInfo(self, layer, side):
+    def environmentLayerJoinObserverInfo(self, layer, side):
         joinInfo = QgsVectorLayerJoinInfo()
         joinInfo.setJoinLayer(layer)
         joinInfo.setJoinFieldName("observer")
@@ -147,4 +156,13 @@ class SammoExportAction(QDialog):
         joinInfo.setJoinFieldNamesSubset(
             ["firstName", "lastName", "organization"]
         )
+        return joinInfo
+
+    def environmentLayerJoinPlateformInfo(self, layer):
+        joinInfo = QgsVectorLayerJoinInfo()
+        joinInfo.setJoinLayer(layer)
+        joinInfo.setJoinFieldName("fid")
+        joinInfo.setTargetFieldName("plateformId")
+        joinInfo.setPrefix("")
+        joinInfo.setJoinFieldNamesSubset(["plateform", "plateformHeight"])
         return joinInfo

--- a/src/gui/export.py
+++ b/src/gui/export.py
@@ -30,7 +30,7 @@ from ..core.session import SammoSession
 class SammoExportAction(QDialog):
     def __init__(
         self, parent: QObject, toolbar: QToolBar, session: SammoSession
-    ):
+    ) -> None:
         super().__init__()
         uic.loadUi(Path(__file__).parent / "ui/export.ui", self)
         self.action: QAction = None
@@ -42,7 +42,7 @@ class SammoExportAction(QDialog):
         self.exportButton.clicked.connect(self.export)
         self.exportButton.setEnabled(False)
 
-    def setEnabled(self, status):
+    def setEnabled(self, status: bool) -> None:
         self.action.setEnabled(status)
         self.action.setChecked(False)
 
@@ -53,7 +53,7 @@ class SammoExportAction(QDialog):
         self.action.setToolTip("Export session")
         toolbar.addAction(self.action)
 
-    def updateSaveFolder(self):
+    def updateSaveFolder(self) -> None:
         path = QFileDialog.getExistingDirectory(
             self,
             "Export folder",
@@ -64,7 +64,7 @@ class SammoExportAction(QDialog):
             self.saveFolderEdit.setText(path)
             self.exportButton.setEnabled(True)
 
-    def export(self):
+    def export(self) -> None:
         driver = self.driverComboBox.currentText()
         if driver not in ["CSV", "GPKG"]:
             self.progressBar.setFormat("Unknown driver: aborting export")
@@ -136,7 +136,7 @@ class SammoExportAction(QDialog):
             self.progressBar.setValue(int(100 / nb * (i + 1)))
         self.close()
 
-    def sightingsLayerJoinInfo(self, layer):
+    def sightingsLayerJoinInfo(self, layer: QgsVectorLayer) -> None:
         joinInfo = QgsVectorLayerJoinInfo()
         joinInfo.setJoinLayer(layer)
         joinInfo.setJoinFieldName("species")
@@ -147,7 +147,9 @@ class SammoExportAction(QDialog):
         )
         return joinInfo
 
-    def environmentLayerJoinObserverInfo(self, layer, side):
+    def environmentLayerJoinObserverInfo(
+        self, layer: QgsVectorLayer, side: str
+    ) -> None:
         joinInfo = QgsVectorLayerJoinInfo()
         joinInfo.setJoinLayer(layer)
         joinInfo.setJoinFieldName("observer")
@@ -158,7 +160,7 @@ class SammoExportAction(QDialog):
         )
         return joinInfo
 
-    def environmentLayerJoinPlateformInfo(self, layer):
+    def environmentLayerJoinPlateformInfo(self, layer: QgsVectorLayer) -> None:
         joinInfo = QgsVectorLayerJoinInfo()
         joinInfo.setJoinLayer(layer)
         joinInfo.setJoinFieldName("fid")

--- a/src/gui/settings.py
+++ b/src/gui/settings.py
@@ -70,6 +70,7 @@ class SammoSettingsDialog(QDialog, FORM_CLASS):
         if vl == self.session.boatLayer:
             self.session.plateformLayer
             dlg = QDialog(self)
+            dlg.setModal(True)
             dlg.setWindowTitle(vl.name())
             table = iface.showAttributeTable(vl)
             originDlg = table.parent()

--- a/src/gui/settings.py
+++ b/src/gui/settings.py
@@ -45,12 +45,13 @@ class SammoSettingsDialog(QDialog, FORM_CLASS):
     def __init__(self, session):
         super().__init__()
         self.setupUi(self)
+        self.setModal(False)
         self.session = session
 
         self.surveyButton.clicked.connect(self.surveyEdit)
         self.transectButton.clicked.connect(self.surveyEdit)
         self.strateButton.clicked.connect(self.surveyEdit)
-        self.plateformButton.clicked.connect(self.surveyEdit)
+        self.boatButton.clicked.connect(self.surveyEdit)
         self.closeButton.clicked.connect(self.close)
 
     def surveyEdit(self):
@@ -60,12 +61,25 @@ class SammoSettingsDialog(QDialog, FORM_CLASS):
             vl = self.session.transectLayer
         elif self.sender() == self.strateButton:
             vl = self.session.strateLayer
-        elif self.sender() == self.plateformButton:
-            vl = self.session.plateformLayer
+        elif self.sender() == self.boatButton:
+            vl = self.session.boatLayer
         vl.startEditing()
         if not vl.featureCount():
             feat = QgsVectorLayerUtils.createFeature(vl)
             vl.addFeature(feat)
+        if vl == self.session.boatLayer:
+            self.session.plateformLayer
+            dlg = QDialog(self)
+            dlg.setWindowTitle(vl.name())
+            table = iface.showAttributeTable(vl)
+            originDlg = table.parent()
+            table.setParent(dlg)
+            if originDlg:  # version < 3.28 compatibility
+                originDlg.hide()
+            dlg.show()
+            dlg.destroyed.connect(vl.commitChanges)
+            dlg.destroyed.connect(self.session.plateformLayer.commitChanges)
+            return
         feat = next(vl.getFeatures())
         iface.openFeatureForm(vl, feat)
         vl.commitChanges()

--- a/src/gui/settings.py
+++ b/src/gui/settings.py
@@ -52,6 +52,7 @@ class SammoSettingsDialog(QDialog, FORM_CLASS):
         self.transectButton.clicked.connect(self.surveyEdit)
         self.strateButton.clicked.connect(self.surveyEdit)
         self.boatButton.clicked.connect(self.surveyEdit)
+        self.plateformButton.clicked.connect(self.surveyEdit)
         self.closeButton.clicked.connect(self.close)
 
     def surveyEdit(self):
@@ -61,13 +62,15 @@ class SammoSettingsDialog(QDialog, FORM_CLASS):
             vl = self.session.transectLayer
         elif self.sender() == self.strateButton:
             vl = self.session.strateLayer
+        elif self.sender() == self.plateformButton:
+            vl = self.session.plateformLayer
         elif self.sender() == self.boatButton:
             vl = self.session.boatLayer
         vl.startEditing()
         if not vl.featureCount():
             feat = QgsVectorLayerUtils.createFeature(vl)
             vl.addFeature(feat)
-        if vl == self.session.boatLayer:
+        if vl in [self.session.boatLayer, self.session.plateformLayer]:
             self.session.plateformLayer
             dlg = QDialog(self)
             dlg.setModal(True)

--- a/src/gui/ui/settings.ui
+++ b/src/gui/ui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>193</height>
+    <height>211</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,9 +42,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="plateformButton">
+       <widget class="QPushButton" name="boatButton">
         <property name="text">
-         <string>Plateform</string>
+         <string>Boat</string>
         </property>
        </widget>
       </item>

--- a/src/gui/ui/settings.ui
+++ b/src/gui/ui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>211</height>
+    <height>242</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -45,6 +45,13 @@
        <widget class="QPushButton" name="boatButton">
         <property name="text">
          <string>Boat</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="plateformButton">
+        <property name="text">
+         <string>Plateform</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This MR adds a better plateform management. For now we have a plateform layer with a single entity handled by the settings menu.

With this changes, it is possible to define several boats, and define plateforms for each of it. Futhermore, the survey entity (handled by settings menu too) allows to define which boat is used for the survey. With this configuration, a new effort entity is added with the current boat name, and this name allows to filter the available plateforms.

At the export, a attribute join is made between the environnement layer and the plateform layer to add plateform name and plateform height to the exported data. 